### PR TITLE
commented out local setting of env vars as doesn't work on GHA

### DIFF
--- a/src/monitor_imerg.R
+++ b/src/monitor_imerg.R
@@ -53,8 +53,8 @@ BAS4_ID_AOI <- c(
 # separately. I think it could be due to a newer version of gdal on runner w/
 # slighly different requirements for accessing azure storage.
 
-Sys.setenv(AZURE_SAS = Sys.getenv("DSCI_AZ_SAS_DEV"))
-Sys.setenv(AZURE_STORAGE_ACCOUNT = Sys.getenv("DSCI_AZ_STORAGE_ACCOUNT"))
+# Sys.setenv(AZURE_SAS = Sys.getenv("DSCI_AZ_SAS_DEV"))
+# Sys.setenv(AZURE_STORAGE_ACCOUNT = Sys.getenv("DSCI_AZ_STORAGE_ACCOUNT"))
 
 
 # Create container end points ---------------------------------------------


### PR DESCRIPTION
forgot to comment these out - in the last merge to main.

Annoyingly, this works locally, but not on the runner. As said somewhere in the last PR I think it's due to an update in env var handling in the newer version of gdal that gets installed on the runner